### PR TITLE
バグ修正

### DIFF
--- a/ios/Parjob/Parjob.xcodeproj/project.pbxproj
+++ b/ios/Parjob/Parjob.xcodeproj/project.pbxproj
@@ -981,6 +981,7 @@
 				CODE_SIGN_ENTITLEMENTS = Parjob/Parjob.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = TLVYAZUQZL;
 				INFOPLIST_FILE = Parjob/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Parjob/Parjob/Calendar/CalendarViewController.swift
+++ b/ios/Parjob/Parjob/Calendar/CalendarViewController.swift
@@ -147,8 +147,9 @@ extension CalendarViewController {
         self.calendar.right(to: self.view)
         heightConst = self.calendar.height(self.view.frame.height/2)
         
-        // view追加後でないとscopeがnilになるためここでセット
+        // view追加後でないとnilになるためここでセット
         setStartEndDate()
+        setUpTodayColor(didSelectedDate: presenter.getCurrentAndPageDate().currentDate)
     }
     
     fileprivate func initializeScrollView() {
@@ -279,6 +280,7 @@ extension CalendarViewController {
         // 通知タップでアプリ起動
         }else if updatedFromUserOption != nil {
             scrollTableViewToUserSection(date: updatedFromUserOption!)
+            MyApplication.shared.updated = nil
             
         // 通常の画面更新
         }else {

--- a/ios/Parjob/Parjob/Info.plist
+++ b/ios/Parjob/Parjob/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
・通知をタップした後に、todayのカラーと選択中のカラーの両方が表示されてしまう問題を修正。
・通知をタップしてアプリを起動した後に、スクロールでカレンダーを移動させた際に落ちる問題を修正。